### PR TITLE
Restructure code and implement JSON output formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "elmjs-inspect",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
@@ -20,7 +19,45 @@
         "@types/esprima": "^4.0.2",
         "@types/estree": "^0.0.51",
         "@types/node": "^13.11.0",
+        "ts-node": "^10.9.1",
         "typescript": "^4.7.4"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@slimio/is": {
@@ -30,6 +67,30 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "node_modules/@types/esprima": {
       "version": "4.0.2",
@@ -52,12 +113,54 @@
       "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==",
       "dev": true
     },
+    "node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/commander": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
       "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/esprima": {
@@ -72,12 +175,61 @@
         "node": ">=4"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/node-estree": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/node-estree/-/node-estree-3.1.0.tgz",
       "integrity": "sha512-Au8RrdfNCbvzT3/POUQjQnArLGpqXpuLrK0fU0acGSynjRA1CFWQ6mExO8HPR7mc9Q4RqemNJg/yTvm3E2nBqw==",
       "dependencies": {
         "@slimio/is": "^1.5.1"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/typescript": {
@@ -92,13 +244,83 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
   },
   "dependencies": {
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@slimio/is": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@slimio/is/-/is-1.5.1.tgz",
       "integrity": "sha512-xQ0AgodIE8nHYy508AVmpxqnIr/Ytyz5Xm7I6NQU33+RvDzs94T9c0dTnUWuariByLr1geXXe6kMaTM9TcOIEA=="
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "@types/esprima": {
       "version": "4.0.2",
@@ -121,15 +343,51 @@
       "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==",
       "dev": true
     },
+    "acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "commander": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
       "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node-estree": {
       "version": "3.1.0",
@@ -139,10 +397,43 @@
         "@slimio/is": "^1.5.1"
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/esprima": "^4.0.2",
     "@types/estree": "^0.0.51",
     "@types/node": "^13.11.0",
+    "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
   "dependencies": {

--- a/src/contracts/ElmJsDefinition.ts
+++ b/src/contracts/ElmJsDefinition.ts
@@ -1,0 +1,4 @@
+export type ElmJsDefinition = {
+  name: string;
+  range: [number, number];
+};

--- a/src/contracts/Format.ts
+++ b/src/contracts/Format.ts
@@ -1,0 +1,1 @@
+export type Format = "text" | "json";

--- a/src/contracts/Formatter.ts
+++ b/src/contracts/Formatter.ts
@@ -1,0 +1,9 @@
+import { ElmJsDefinition } from "./ElmJsDefinition";
+import { Summary } from "./Summary";
+import { Range } from "./Range";
+
+export type Formatter = (
+  definitions: ElmJsDefinition[],
+  summaryType: Summary,
+  parsedRange: Range
+) => string;

--- a/src/contracts/Options.ts
+++ b/src/contracts/Options.ts
@@ -1,0 +1,7 @@
+import { Summary } from "./Summary";
+import { Format } from "./Format";
+
+export type Options = {
+  summary: Summary;
+  format: Format;
+};

--- a/src/contracts/Range.ts
+++ b/src/contracts/Range.ts
@@ -1,0 +1,1 @@
+export type Range = [number, number];

--- a/src/contracts/Summary.ts
+++ b/src/contracts/Summary.ts
@@ -1,0 +1,1 @@
+export type Summary = "module" | "package" | "project";

--- a/src/formatters/jsonFormatter.ts
+++ b/src/formatters/jsonFormatter.ts
@@ -1,0 +1,20 @@
+import { Range } from "../contracts/Range";
+import { Summary } from "../contracts/Summary";
+import { summaryGenerator } from "../utils/generateSummary";
+import { rangeSize } from "../utils/rangeSize";
+import { ElmJsDefinition } from "../contracts/ElmJsDefinition";
+import { percent } from "../utils/percent";
+
+export function jsonFormatter(
+  definitions: ElmJsDefinition[],
+  summaryType: Summary,
+  parsedRange: Range
+) {
+  const summary = summaryGenerator(definitions, summaryType);
+  const entries = Array.from(summary.entries()).sort((a, b) => b[1] - a[1]);
+  const formattedEntries = entries.map(([name, range]) => ({
+    [name]: percent(range, rangeSize(parsedRange)),
+  }));
+
+  return JSON.stringify(formattedEntries);
+}

--- a/src/formatters/textFormatter.ts
+++ b/src/formatters/textFormatter.ts
@@ -1,0 +1,22 @@
+import { Range } from "../contracts/Range";
+import { Summary } from "../contracts/Summary";
+import { summaryGenerator } from "../utils/generateSummary";
+import { rangeSize } from "../utils/rangeSize";
+import { ElmJsDefinition } from "../contracts/ElmJsDefinition";
+import { percent } from "../utils/percent";
+
+export function textFormatter(
+  definitions: ElmJsDefinition[],
+  summaryType: Summary,
+  parsedRange: Range
+) {
+  const summary = summaryGenerator(definitions, summaryType);
+  const entries = Array.from(summary.entries());
+  entries.sort((a, b) => b[1] - a[1]);
+
+  return entries
+    .map(
+      ([name, range]) => `${name}: ${percent(range, rangeSize(parsedRange))}`
+    )
+    .join("\n");
+}

--- a/src/generators/elmFunctionDeclarationInformation.ts
+++ b/src/generators/elmFunctionDeclarationInformation.ts
@@ -1,0 +1,12 @@
+import * as ESTree from "estree";
+
+export function* elmFunctionDeclarationInformation(
+  statement: ESTree.Statement
+) {
+  if (statement.type === "FunctionDeclaration") {
+    yield {
+      name: statement.id?.name ?? "anonymous",
+      range: statement.range,
+    };
+  }
+}

--- a/src/generators/elmJsDefinitions.ts
+++ b/src/generators/elmJsDefinitions.ts
@@ -1,0 +1,14 @@
+import * as Esprima from "esprima";
+import { ElmJsDefinition } from "../contracts/ElmJsDefinition";
+import { elmJsStatements } from "./elmJsStatements";
+import { elmFunctionDeclarationInformation } from "./elmFunctionDeclarationInformation";
+import { elmVariableDeclarationInformation } from "./elmVariableDeclarationInformation";
+
+export function* elmJsDefinitions(
+  script: Esprima.Program
+): Generator<ElmJsDefinition> {
+  for (const statement of elmJsStatements(script)) {
+    yield* elmFunctionDeclarationInformation(statement);
+    yield* elmVariableDeclarationInformation(statement);
+  }
+}

--- a/src/generators/elmJsStatements.ts
+++ b/src/generators/elmJsStatements.ts
@@ -1,0 +1,13 @@
+import * as Esprima from "esprima";
+
+export function* elmJsStatements(script: Esprima.Program) {
+  for (const e of script.body) {
+    if (
+      e.type === "ExpressionStatement" &&
+      e.expression.type === "CallExpression" &&
+      e.expression.callee.type === "FunctionExpression"
+    ) {
+      yield* e.expression.callee.body.body;
+    }
+  }
+}

--- a/src/generators/elmVariableDeclarationInformation.ts
+++ b/src/generators/elmVariableDeclarationInformation.ts
@@ -1,0 +1,16 @@
+import * as ESTree from "estree";
+
+export function* elmVariableDeclarationInformation(
+  statement: ESTree.Statement
+) {
+  if (statement.type === "VariableDeclaration") {
+    for (const declaration of statement.declarations) {
+      if (declaration.id.type === "Identifier") {
+        yield {
+          name: declaration.id.name,
+          range: declaration.range,
+        };
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,16 +6,18 @@ import { analyze } from "./analyze.js";
 program
   .name("elmjs-inspect")
   .description("Analyze your elm.js file size with this tool.")
-  .version("1.1.0");
-
-program
-  .option(
+  .version("1.1.0")
+  .requiredOption(
     "-s, --summary [value]",
     "Display summary. Possible values: module, package, project"
+  )
+  .option(
+    "-f, --format [value]",
+    "Display format. Possible values: json, text",
+    "text"
   )
   .argument("<filename>", "The file to analyze")
   .action((filename, opts) => {
     analyze(filename, opts);
-  });
-
-program.parse();
+  })
+  .parse();

--- a/src/parsers/localNameParser.ts
+++ b/src/parsers/localNameParser.ts
@@ -1,0 +1,5 @@
+export function localNameParser(name: string) {
+  return !name.startsWith("$author")
+    ? "Dependencies"
+    : name.slice(16, name.lastIndexOf("$")).replaceAll("$", ".");
+}

--- a/src/parsers/moduleNameParser.ts
+++ b/src/parsers/moduleNameParser.ts
@@ -1,0 +1,9 @@
+export function moduleNameParser(name: string) {
+  const packageName = name.split("$").slice(1, 3).join("/");
+  const moduleName = name.split("$").slice(3).join(".");
+  const prettifiedName = `${packageName}: ${moduleName}`;
+
+  return !name.startsWith("$")
+    ? "Kernel Code"
+    : prettifiedName.slice(0, prettifiedName.lastIndexOf("."));
+}

--- a/src/parsers/packageNameParser.ts
+++ b/src/parsers/packageNameParser.ts
@@ -1,0 +1,5 @@
+export function packageNameParser(name: string) {
+  return !name.startsWith("$")
+    ? "Kernel Code"
+    : name.split("$").slice(1, 3).join("/");
+}

--- a/src/utils/formatterForFormat.ts
+++ b/src/utils/formatterForFormat.ts
@@ -1,0 +1,20 @@
+import { Format } from "../contracts/Format";
+import { Formatter } from "../contracts/Formatter";
+import { textFormatter } from "../formatters/textFormatter";
+import { jsonFormatter } from "../formatters/jsonFormatter";
+import { Range } from "../contracts/Range";
+import { Summary } from "../contracts/Summary";
+import { ElmJsDefinition } from "../contracts/ElmJsDefinition";
+
+export function formatterForFormat(format: Format): Formatter {
+  const formatter: Formatter =
+    format === "text" ? textFormatter : jsonFormatter;
+
+  return (
+    definitions: ElmJsDefinition[],
+    summaryType: Summary,
+    parsedRange: Range
+  ) => {
+    return formatter(definitions, summaryType, parsedRange);
+  };
+}

--- a/src/utils/generateSummary.ts
+++ b/src/utils/generateSummary.ts
@@ -1,0 +1,21 @@
+import { ElmJsDefinition } from "../contracts/ElmJsDefinition";
+import { Summary } from "../contracts/Summary";
+import { keyForSummaryType } from "./keyForSummaryType";
+import { rangeSize } from "./rangeSize";
+
+export function summaryGenerator(
+  definitions: ElmJsDefinition[],
+  summaryType: Summary
+) {
+  return definitions.reduce(
+    (accumulator: Map<string, number>, { name, range }) => {
+      const key = keyForSummaryType(name, summaryType);
+
+      return accumulator.set(
+        key,
+        (accumulator.get(key) ?? 0) + rangeSize(range)
+      );
+    },
+    new Map<string, number>()
+  );
+}

--- a/src/utils/keyForSummaryType.ts
+++ b/src/utils/keyForSummaryType.ts
@@ -1,0 +1,16 @@
+import { Summary } from "../contracts/Summary";
+import { localNameParser } from "../parsers/localNameParser";
+import { moduleNameParser } from "../parsers/moduleNameParser";
+import { packageNameParser } from "../parsers/packageNameParser";
+
+export function keyForSummaryType(name: string, summaryType: Summary) {
+  if (summaryType === "package") {
+    return packageNameParser(name);
+  }
+
+  if (summaryType === "project") {
+    return localNameParser(name);
+  }
+
+  return moduleNameParser(name);
+}

--- a/src/utils/percent.ts
+++ b/src/utils/percent.ts
@@ -1,0 +1,3 @@
+export function percent(x: number, y: number) {
+  return `${Number((x / y) * 100).toFixed(3)}%`;
+}

--- a/src/utils/rangeSize.ts
+++ b/src/utils/rangeSize.ts
@@ -1,0 +1,5 @@
+import { Range } from "../contracts/Range";
+
+export function rangeSize([start, end]: Range) {
+  return end - start;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
-    "compilerOptions": {
-        // "target": "ES2019",
-        "module": "ES6",
-        "downlevelIteration": true,
-        "moduleResolution": "node",
-        "outDir": "bin",
-        "lib": ["ES2021.String"]
-    },
-    "files": ["src/analyze.ts", "src/index.ts"]
+  "compilerOptions": {
+    // "target": "ES2019",
+    "module": "ES6",
+    "downlevelIteration": true,
+    "moduleResolution": "node",
+    "outDir": "bin",
+    "lib": ["ES2021.String"]
+  },
+  "files": ["src/analyze.ts", "src/index.ts"]
 }


### PR DESCRIPTION
Fixes #7

- Restructured the `analyze.ts` to logically sort functions into a folder structure.
- Added contract types to ensure we get type guarantees of some sort throughout.
- Added JSON output formatter support.

Perhaps @matheus23 you can help me with two things:

1. Feedback is most welcome and happy to change / discuss anything that comes to mind.
2. For some reason the compilation when running `build` works fine but at runtime there is a "cannot find module" error even though the path it aims to get exists and is a valid module, any ideas?